### PR TITLE
Add Escrow implementation

### DIFF
--- a/contracts/distribution/EscrowAlpha.sol
+++ b/contracts/distribution/EscrowAlpha.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.6.11;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IVestingAlpha.sol";
+import "./AlphaToken.sol";
+
+/**
+ * @title Alpha escrow contract.
+ * @author Alpha
+ *
+ * Implements Alpha escrow contract. Whenever you withdraw, you pay
+ * withdraw premium to other existing users who have not withdrawn yet.
+ */
+
+contract EscrowAlpha is IVestingAlpha, Ownable, ReentrancyGuard {
+  using SafeMath for uint256;
+
+  /**
+   * @dev emitted on accumulate Alpha token
+   * @param user the account of user
+   * @param share the shrare that the user receives
+   * @param amount the amount of Alpha token to accumulate
+   */
+  event AlphaTokenAccumulated(address indexed user, uint256 share, uint256 amount);
+  /**
+   * @dev emitted on withdraw Alpha token
+   * @param user the account of user
+   * @param share the shrare that the user burns
+   * @param amount the amount of Alpha token that the user receives
+   */
+  event AlphaTokenWithdrawn(address indexed user, uint256 share, uint256 amount);
+
+  // alpha token
+  AlphaToken public alphaToken;
+  // user => accumulate vesting share
+  mapping(address => uint256) public shares;
+  // total share of all users
+  uint256 public totalShare;
+  // reward withdraw penalty distributed to other token vesters.
+  uint256 public withdrawPremium;
+
+  constructor(AlphaToken _alphaToken, uint256 _withdrawPremium) public {
+    alphaToken = _alphaToken;
+    withdrawPremium = _withdrawPremium;
+  }
+
+  /**
+   * @dev accumulate Alpha token to user
+   * @param _user the user account address
+   * @param _amount the amount of Alpha token to accumulate
+   */
+  function accumulateAlphaToUser(address _user, uint256 _amount) external override nonReentrant {
+    uint256 supply = alphaToken.balanceOf(address(this));
+    uint256 share = supply == 0 ? _amount : _amount.mul(totalShare).div(supply);
+    shares[_user] = shares[_user].add(share);
+    totalShare = totalShare.add(share);
+    alphaToken.transferFrom(msg.sender, address(this), _amount);
+    emit AlphaTokenAccumulated(_user, share, _amount);
+  }
+
+  /**
+   * @dev claim Alpha token by burning shares (need to pay withdraw premium)
+   * @param _share the number of shares to burn and claim Alpha
+   */
+  function claim(uint256 _share) external nonReentrant {
+    uint256 supply = alphaToken.balanceOf(address(this));
+    uint256 amount = _share.mul(supply).div(totalShare).mul(withdrawPremium).div(1e18);
+    shares[msg.sender] = shares[msg.sender].sub(_share);
+    totalShare = totalShare.sub(_share);
+    alphaToken.transfer(msg.sender, amount);
+    emit AlphaTokenWithdrawn(msg.sender, _share, amount);
+  }
+
+  /**
+   * @dev recover left-over Alpha token. Must only be called from owner
+   * @param _amount the number of Alpha token to withdraw
+   */
+  function recover(uint256 _amount) external onlyOwner {
+    alphaToken.transfer(msg.sender, _amount);
+  }
+
+  /**
+   * @dev update withdraw premium parameter
+   * @param _withdrawPremium the new withdraw premium parameter
+   */
+  function setWithdrawPremium(uint256 _withdrawPremium) external onlyOwner {
+    withdrawPremium = _withdrawPremium;
+  }
+}

--- a/contracts/distribution/EscrowAlpha.sol
+++ b/contracts/distribution/EscrowAlpha.sol
@@ -39,12 +39,12 @@ contract EscrowAlpha is IVestingAlpha, Ownable, ReentrancyGuard {
   mapping(address => uint256) public shares;
   // total share of all users
   uint256 public totalShare;
-  // reward withdraw penalty distributed to other token vesters.
-  uint256 public withdrawPremium;
+  // 1e18 - reward withdraw penalty distributed to other token vesters.
+  uint256 public withdrawPortion;
 
-  constructor(AlphaToken _alphaToken, uint256 _withdrawPremium) public {
+  constructor(AlphaToken _alphaToken, uint256 _withdrawPortion) public {
     alphaToken = _alphaToken;
-    withdrawPremium = _withdrawPremium;
+    withdrawPortion = _withdrawPortion;
   }
 
   /**
@@ -62,12 +62,12 @@ contract EscrowAlpha is IVestingAlpha, Ownable, ReentrancyGuard {
   }
 
   /**
-   * @dev claim Alpha token by burning shares (need to pay withdraw premium)
+   * @dev claim Alpha token by burning shares (get less because of withdraw premium)
    * @param _share the number of shares to burn and claim Alpha
    */
   function claim(uint256 _share) external nonReentrant {
     uint256 supply = alphaToken.balanceOf(address(this));
-    uint256 amount = _share.mul(supply).div(totalShare).mul(withdrawPremium).div(1e18);
+    uint256 amount = _share.mul(supply).div(totalShare).mul(withdrawPortion).div(1e18);
     shares[msg.sender] = shares[msg.sender].sub(_share);
     totalShare = totalShare.sub(_share);
     alphaToken.transfer(msg.sender, amount);
@@ -83,10 +83,10 @@ contract EscrowAlpha is IVestingAlpha, Ownable, ReentrancyGuard {
   }
 
   /**
-   * @dev update withdraw premium parameter
-   * @param _withdrawPremium the new withdraw premium parameter
+   * @dev update withdraw portion parameter
+   * @param _withdrawPortion the new withdraw portion parameter
    */
-  function setWithdrawPremium(uint256 _withdrawPremium) external onlyOwner {
-    withdrawPremium = _withdrawPremium;
+  function setwithdrawPortion(uint256 _withdrawPortion) external onlyOwner {
+    withdrawPortion = _withdrawPortion;
   }
 }

--- a/contracts/distribution/VestingAlpha.sol
+++ b/contracts/distribution/VestingAlpha.sol
@@ -75,7 +75,7 @@ contract VestingAlpha is IVestingAlpha, ReentrancyGuard {
   /**
    * @dev create receipt for caller
    */
-  function createReceipt() external override nonReentrant returns (uint256) {
+  function createReceipt() external nonReentrant returns (uint256) {
     uint256 amount = userAccumulatedAlpha[msg.sender];
     require(amount > 0, "User don't have accumulate Alpha to create receipt");
     receipts.push(
@@ -90,7 +90,7 @@ contract VestingAlpha is IVestingAlpha, ReentrancyGuard {
    * @dev claim receipt by receipt ID
    * @param _receiptID the ID of the receipt to claim
    */
-  function claim(uint256 _receiptID) external override nonReentrant {
+  function claim(uint256 _receiptID) external nonReentrant {
     require(_receiptID < receipts.length, "Receipt ID not found");
     Receipt storage receipt = receipts[_receiptID];
     require(receipt.claimedAmount < receipt.amount, "This receipt has been claimed all tokens");

--- a/contracts/interfaces/IVestingAlpha.sol
+++ b/contracts/interfaces/IVestingAlpha.sol
@@ -8,22 +8,11 @@ pragma solidity 0.6.11;
  */
 
 interface IVestingAlpha {
-  
+
   /**
    * @dev accumulate Alpha token to user
    * @param _user the user account address
    * @param _amount the amount of Alpha token to accumulate
    */
   function accumulateAlphaToUser(address _user, uint256 _amount) external;
-
-  /**
-   * @dev create receipt for caller
-   */
-  function createReceipt() external returns (uint256);
-
-  /**
-   * @dev claim receipt by receipt ID
-   * @param _receiptID the ID of the receipt to claim
-   */
-  function claim(uint256 _receiptID) external;
 }

--- a/test/EscrowAlpha.test.js
+++ b/test/EscrowAlpha.test.js
@@ -8,8 +8,8 @@ const chai = require("chai");
 const {expect, assert} = require("chai");
 chai.use(require("chai-bignumber")(BigNumber));
 
-contract.only("EscrowAlpha", ([creator, alice, bob]) => {
-  const WITHDRAW_PORTION= BigNumber(0.7).times(WAD); // user can withdraw 70% portion
+contract.only("EscrowAlpha", ([creator, alice, bob, carol]) => {
+  const WITHDRAW_PORTION = BigNumber(0.7).times(WAD); // user can withdraw 70% portion
   beforeEach(async () => {
     this.alphaToken = await AlphaToken.new();
     await this.alphaToken.mint(creator, "10000000");
@@ -17,13 +17,39 @@ contract.only("EscrowAlpha", ([creator, alice, bob]) => {
   });
 
   it("Should accumulate Alpha to user and user can claim Alpha", async () => {
-    // Alice got 100 Alpha
-    await this.alphaToken.approve(this.escrow.address, "100");
+    await this.alphaToken.approve(this.escrow.address, "10000000");
+    // Alice gets 100 Alpha
     await this.escrow.accumulateAlphaToUser(alice, "100");
-
-    // Bob got 100 Alpha
-    await this.alphaToken.approve(this.escrow.address, "100");
+    // Bob gets 100 Alpha
     await this.escrow.accumulateAlphaToUser(bob, "100");
-
-  })
-})
+    // Carol gets 100 Alpha
+    await this.escrow.accumulateAlphaToUser(carol, "100");
+    // Alice withdraws and should get 70 tokens back
+    await this.escrow.claim("100", {from: alice});
+    expect(BigNumber(await this.alphaToken.balanceOf(alice))).to.be.bignumber.eq(BigNumber("70"));
+    expect(BigNumber(await this.alphaToken.balanceOf(this.escrow.address))).to.be.bignumber.eq(
+      BigNumber("230")
+    );
+    // Bob withdraws half of his share and should get 230/4 = 57, 57*7/10 = 39 tokens back
+    await this.escrow.claim("50", {from: bob});
+    expect(BigNumber(await this.alphaToken.balanceOf(bob))).to.be.bignumber.eq(BigNumber("39"));
+    // Bob gets another 100 Alpha. Should translate to 100*150/191 = 78 share
+    await this.escrow.accumulateAlphaToUser(bob, "100");
+    expect(BigNumber(await this.escrow.shares(bob))).to.be.bignumber.eq(BigNumber("128"));
+    // Carol withdraws all tokens. Should get (400-70-39)*100/236 = 127, 123*7/10 = 88 tokens back
+    await this.escrow.claim("100", {from: carol});
+    expect(BigNumber(await this.alphaToken.balanceOf(carol))).to.be.bignumber.eq(BigNumber("88"));
+    // Bob withdraws all tokens. Should get (400-70-39-88) = 203, 203*7/10 = 142 tokens back (+existing 39)
+    await this.escrow.claim("128", {from: bob});
+    expect(BigNumber(await this.alphaToken.balanceOf(bob))).to.be.bignumber.eq(BigNumber("181"));
+    // Non owner should not be able to recover
+    await truffleAssert.reverts(
+      this.escrow.recover("61", {from: alice}),
+      "Ownable: caller is not the owner"
+    );
+    await this.escrow.recover("61");
+    expect(BigNumber(await this.alphaToken.balanceOf(creator))).to.be.bignumber.eq(
+      BigNumber("9999661")
+    );
+  });
+});

--- a/test/EscrowAlpha.test.js
+++ b/test/EscrowAlpha.test.js
@@ -1,0 +1,33 @@
+const AlphaToken = artifacts.require("AlphaToken");
+const EscrowAlpha = artifacts.require("EscrowAlpha");
+const truffleAssert = require("truffle-assertions");
+const {time} = require("@openzeppelin/test-helpers");
+const {WAD} = require("./helper.js");
+const BigNumber = require("bignumber.js");
+const chai = require("chai");
+const {expect, assert} = require("chai");
+chai.use(require("chai-bignumber")(BigNumber));
+
+contract.only("EscrowAlpha", ([creator, alice, bob]) => {
+  const WITHDRAW_PORTION= BigNumber(0.7).times(WAD); // user can withdraw 70% portion
+  beforeEach(async () => {
+    this.alphaToken = await AlphaToken.new();
+    await this.alphaToken.mint(creator, "10000000");
+    this.escrow = await EscrowAlpha.new(this.alphaToken.address, WITHDRAW_PORTION);
+  });
+
+  it("Should accumulate Alpha to user and user can claim Alpha", async () => {
+    // Alice got 100 Alpha
+    await this.alphaToken.approve(this.escrow.address, "100");
+    await this.escrow.accumulateAlphaToUser(alice, "100");
+
+    // Alice got 100 Alpha
+    await this.alphaToken.approve(this.escrow.address, "100");
+    await this.escrow.accumulateAlphaToUser(alice, "100");
+
+    // Bob got 100 Alpha
+    await this.alphaToken.approve(this.escrow.address, "100");
+    await this.escrow.accumulateAlphaToUser(bob, "100");
+
+  })
+})

--- a/test/EscrowAlpha.test.js
+++ b/test/EscrowAlpha.test.js
@@ -21,10 +21,6 @@ contract.only("EscrowAlpha", ([creator, alice, bob]) => {
     await this.alphaToken.approve(this.escrow.address, "100");
     await this.escrow.accumulateAlphaToUser(alice, "100");
 
-    // Alice got 100 Alpha
-    await this.alphaToken.approve(this.escrow.address, "100");
-    await this.escrow.accumulateAlphaToUser(alice, "100");
-
     // Bob got 100 Alpha
     await this.alphaToken.approve(this.escrow.address, "100");
     await this.escrow.accumulateAlphaToUser(bob, "100");


### PR DESCRIPTION
An escrow smart contract that disincentivizes token withdraw. Whenever you withdraw, you pay some premium (say 30%) to everyone still in the pool. That way if you stay you can actually earn more. And you get less if you leave early.